### PR TITLE
add route for a buyer to accept an offer

### DIFF
--- a/controllers/offerController.js
+++ b/controllers/offerController.js
@@ -160,6 +160,20 @@ module.exports = {
         }
     },
 
+    // BUYER ACCEPT OFFER
+    buyerAcceptOffer: async (req, res) => {
+        const { offerId } = req.body;
+
+        const offer = await db.Offer.findById(offerId);
+
+        offer.buyerAcceptance = true;
+
+        offer
+            .save()
+            .then(doc => res.json(doc))
+            .catch(err => res.json(err));
+    },
+
     // GET ALL OFFERS BELONGING TO A SELLER
     getOffers: async (req, res) => {
         const homes = await db.Property.find({

--- a/models/offerSchema.js
+++ b/models/offerSchema.js
@@ -50,6 +50,10 @@ const OfferSchema = new Schema({
     },
     sellerPurchaseAgreement: {
         type: String
+    },
+    buyerAcceptance: {
+        type: Boolean,
+        default: false
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "main": "server.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
-        "start": "node server.js"
+        "start": "nodemon server.js"
     },
     "author": "",
     "license": "ISC",

--- a/routes/api/offer.js
+++ b/routes/api/offer.js
@@ -19,4 +19,6 @@ router.route("/acceptoffer").post(offerController.acceptOffer);
 
 router.route("/offer/:offer_id").get(offerController.offerInfo);
 
+router.route("acceptoffer/buyer").post(offerController.buyerAcceptOffer);
+
 module.exports = router;


### PR DESCRIPTION
This is the route and controller action for a buyer to accept an offer. Right now there is no way that a buyer can confirm that they accept an offer after the seller has uploaded the signed purchase agreement. This action will be called from the decisioning section in the buyer dashboard